### PR TITLE
Add missing header file <limits>

### DIFF
--- a/cxxopts/include/cxxopts.hpp
+++ b/cxxopts/include/cxxopts.hpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 #ifndef CXXOPTS_HPP_INCLUDED
 #define CXXOPTS_HPP_INCLUDED
-
+#include <limits>
 #include <cstring>
 #include <cctype>
 #include <exception>


### PR DESCRIPTION
`std::numeric_limits` is declared in header file `<limits>`. It is used in

https://github.com/sudden6/m-queens/blob/7702c03de3d4a7e800af94ee947ff4f2d5d53fea/cxxopts/include/cxxopts.hpp#L471